### PR TITLE
catch case where n_eligible_for_doseX is 0, avoid division by 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mpoxseir
 Title: Stochastic compartmental model of mpox transmission
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Lilith", "Whittles", role = c("aut", "cre"),
                     email = "l.whittles@imperial.ac.uk"),
              person("Ruth", "McCabe", role = c("aut")),

--- a/inst/dust/model-targeted-vax.cpp
+++ b/inst/dust/model-targeted-vax.cpp
@@ -576,11 +576,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Ea_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Ea[shared->dim_Ea_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Ea[shared->dim_Ea_1 * 1 + i - 1]);
+      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Ea[shared->dim_Ea_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Ea[shared->dim_Ea_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Ea_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Ea[shared->dim_Ea_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Ea[shared->dim_Ea_1 * 2 + i - 1]);
+      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Ea[shared->dim_Ea_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Ea[shared->dim_Ea_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_Eb_2; ++j) {
@@ -589,11 +589,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Eb[shared->dim_Eb_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Eb[shared->dim_Eb_1 * 1 + i - 1]);
+      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Eb[shared->dim_Eb_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Eb[shared->dim_Eb_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Eb[shared->dim_Eb_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Eb[shared->dim_Eb_1 * 2 + i - 1]);
+      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Eb[shared->dim_Eb_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Eb[shared->dim_Eb_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_R_2; ++j) {
@@ -602,11 +602,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * R[shared->dim_R_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), R[shared->dim_R_1 * 1 + i - 1]);
+      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * R[shared->dim_R_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), R[shared->dim_R_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * R[shared->dim_R_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), R[shared->dim_R_1 * 2 + i - 1]);
+      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * R[shared->dim_R_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), R[shared->dim_R_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_S_2; ++j) {
@@ -615,11 +615,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * S[shared->dim_S_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), S[shared->dim_S_1 * 1 + i - 1]);
+      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * S[shared->dim_S_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), S[shared->dim_S_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * S[shared->dim_S_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), S[shared->dim_S_1 * 2 + i - 1]);
+      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * S[shared->dim_S_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), S[shared->dim_S_1 * 2 + i - 1]));
     }
     real_type prioritisation_step_1st_dose_proposal = (odin_sum2<real_type>(internal.target_met_t.data(), 0, shared->dim_target_met_t_1, 2, 3, shared->dim_target_met_t_1) == shared->n_group ? prioritisation_step_1st_dose + 1 : prioritisation_step_1st_dose);
     real_type prioritisation_step_2nd_dose_proposal = (odin_sum2<real_type>(internal.target_met_t.data(), 0, shared->dim_target_met_t_1, 3, 4, shared->dim_target_met_t_1) == shared->n_group ? prioritisation_step_2nd_dose + 1 : prioritisation_step_2nd_dose);

--- a/inst/odin/model-targeted-vax.R
+++ b/inst/odin/model-targeted-vax.R
@@ -126,55 +126,62 @@ n_vaccination_t_Eb[, ] <- 0
 n_vaccination_t_R[, ] <- 0
 
 ## allocate 1st doses
-n_vaccination_t_S[, 2] <- min(
-  floor((daily_doses_t[1, 2] * S[i, 2] *
-           prioritisation_strategy[i, prioritisation_step_1st_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
-  S[i, 2])
+n_vaccination_t_S[, 2] <- if (sum(n_eligible_for_dose1[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 2] * S[i, 2] *
+               prioritisation_strategy[i, prioritisation_step_1st_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
+      S[i, 2])
+  
 
-n_vaccination_t_Ea[, 2] <- min(
-  floor((daily_doses_t[1, 2] * Ea[i, 2] *
-           prioritisation_strategy[i, prioritisation_step_1st_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
-  Ea[i, 2])
+n_vaccination_t_Ea[, 2] <- if (sum(n_eligible_for_dose1[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 2] * Ea[i, 2] *
+               prioritisation_strategy[i, prioritisation_step_1st_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
+      Ea[i, 2])
+  
 
-n_vaccination_t_Eb[, 2] <- min(
-  floor((daily_doses_t[1, 2] * Eb[i, 2] *
-           prioritisation_strategy[i, prioritisation_step_1st_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
-  Eb[i, 2])
+n_vaccination_t_Eb[, 2] <- if (sum(n_eligible_for_dose1[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 2] * Eb[i, 2] *
+               prioritisation_strategy[i, prioritisation_step_1st_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
+      Eb[i, 2])
+  
 
-n_vaccination_t_R[, 2] <- min(
-  floor((daily_doses_t[1, 2] * R[i, 2] *
-           prioritisation_strategy[i, prioritisation_step_1st_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
-  R[i, 2])
+n_vaccination_t_R[, 2] <- if (sum(n_eligible_for_dose1[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 2] * R[i, 2] *
+               prioritisation_strategy[i, prioritisation_step_1st_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose1[])),
+      R[i, 2])
+  
 
 
 ## allocate 2nd doses
-n_vaccination_t_S[, 3] <- min(
+n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
+  min(
   floor((daily_doses_t[1, 3] * S[i, 3] *
            prioritisation_strategy[i, prioritisation_step_2nd_dose] *
            vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
   S[i, 3])
 
-n_vaccination_t_Ea[, 3] <- min(
-  floor((daily_doses_t[1, 3] * Ea[i, 3] *
-           prioritisation_strategy[i, prioritisation_step_2nd_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
-  Ea[i, 3])
+n_vaccination_t_Ea[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 3] * Ea[i, 3] *
+               prioritisation_strategy[i, prioritisation_step_2nd_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
+      Ea[i, 3])
+  
 
-n_vaccination_t_Eb[, 3] <- min(
-  floor((daily_doses_t[1, 3] * Eb[i, 3] *
-           prioritisation_strategy[i, prioritisation_step_2nd_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
-  Eb[i, 3])
+n_vaccination_t_Eb[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 3] * Eb[i, 3] *
+               prioritisation_strategy[i, prioritisation_step_2nd_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
+      Eb[i, 3])
+  
 
-n_vaccination_t_R[, 3] <- min(
-  floor((daily_doses_t[1, 3] * R[i, 3] *
-           prioritisation_strategy[i, prioritisation_step_2nd_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
-  R[i, 3])
+n_vaccination_t_R[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
+  min(floor((daily_doses_t[1, 3] * R[i, 3] *
+               prioritisation_strategy[i, prioritisation_step_2nd_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
+      R[i, 3])
 
 
 ## net vaccination change for relevant classes (S,Ea,Eb,R)

--- a/inst/odin/model-targeted-vax.R
+++ b/inst/odin/model-targeted-vax.R
@@ -157,11 +157,11 @@ n_vaccination_t_R[, 2] <- if (sum(n_eligible_for_dose1[]) == 0) 0 else
 
 ## allocate 2nd doses
 n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
-  min(
-  floor((daily_doses_t[1, 3] * S[i, 3] *
-           prioritisation_strategy[i, prioritisation_step_2nd_dose] *
-           vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
-  S[i, 3])
+  min(floor((daily_doses_t[1, 3] * S[i, 3] *
+               prioritisation_strategy[i, prioritisation_step_2nd_dose] *
+               vaccine_uptake[i]) / sum(n_eligible_for_dose2[])),
+      S[i, 3])
+  
 
 n_vaccination_t_Ea[, 3] <- if (sum(n_eligible_for_dose2[]) == 0) 0 else
   min(floor((daily_doses_t[1, 3] * Ea[i, 3] *

--- a/src/model-targeted-vax.cpp
+++ b/src/model-targeted-vax.cpp
@@ -650,11 +650,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Ea_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Ea[shared->dim_Ea_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Ea[shared->dim_Ea_1 * 1 + i - 1]);
+      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Ea[shared->dim_Ea_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Ea[shared->dim_Ea_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Ea_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Ea[shared->dim_Ea_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Ea[shared->dim_Ea_1 * 2 + i - 1]);
+      internal.n_vaccination_t_Ea[i - 1 + shared->dim_n_vaccination_t_Ea_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Ea[shared->dim_Ea_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Ea[shared->dim_Ea_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_Eb_2; ++j) {
@@ -663,11 +663,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Eb[shared->dim_Eb_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Eb[shared->dim_Eb_1 * 1 + i - 1]);
+      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * Eb[shared->dim_Eb_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), Eb[shared->dim_Eb_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_Eb_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Eb[shared->dim_Eb_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Eb[shared->dim_Eb_1 * 2 + i - 1]);
+      internal.n_vaccination_t_Eb[i - 1 + shared->dim_n_vaccination_t_Eb_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * Eb[shared->dim_Eb_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), Eb[shared->dim_Eb_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_R_2; ++j) {
@@ -676,11 +676,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * R[shared->dim_R_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), R[shared->dim_R_1 * 1 + i - 1]);
+      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * R[shared->dim_R_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), R[shared->dim_R_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_R_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * R[shared->dim_R_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), R[shared->dim_R_1 * 2 + i - 1]);
+      internal.n_vaccination_t_R[i - 1 + shared->dim_n_vaccination_t_R_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * R[shared->dim_R_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), R[shared->dim_R_1 * 2 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       for (int j = 1; j <= shared->dim_n_vaccination_t_S_2; ++j) {
@@ -689,11 +689,11 @@ public:
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       int j = 2;
-      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * S[shared->dim_S_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), S[shared->dim_S_1 * 1 + i - 1]);
+      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 1 + 0] * S[shared->dim_S_1 * 1 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_1st_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose1.data(), 0, shared->dim_n_eligible_for_dose1)), S[shared->dim_S_1 * 1 + i - 1]));
     }
     for (int i = 1; i <= shared->dim_n_vaccination_t_S_1; ++i) {
       int j = 3;
-      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * S[shared->dim_S_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), S[shared->dim_S_1 * 2 + i - 1]);
+      internal.n_vaccination_t_S[i - 1 + shared->dim_n_vaccination_t_S_1 * (j - 1)] = (odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2) == 0 ? 0 : dust::math::min(dust::math::floor((internal.daily_doses_t[shared->dim_daily_doses_t_1 * 2 + 0] * S[shared->dim_S_1 * 2 + i - 1] * shared->prioritisation_strategy[shared->dim_prioritisation_strategy_1 * (prioritisation_step_2nd_dose - 1) + i - 1] * shared->vaccine_uptake[i - 1]) / (real_type) odin_sum1<real_type>(internal.n_eligible_for_dose2.data(), 0, shared->dim_n_eligible_for_dose2)), S[shared->dim_S_1 * 2 + i - 1]));
     }
     real_type prioritisation_step_1st_dose_proposal = (odin_sum2<real_type>(internal.target_met_t.data(), 0, shared->dim_target_met_t_1, 2, 3, shared->dim_target_met_t_1) == shared->n_group ? prioritisation_step_1st_dose + 1 : prioritisation_step_1st_dose);
     real_type prioritisation_step_2nd_dose_proposal = (odin_sum2<real_type>(internal.target_met_t.data(), 0, shared->dim_target_met_t_1, 3, 4, shared->dim_target_met_t_1) == shared->n_group ? prioritisation_step_2nd_dose + 1 : prioritisation_step_2nd_dose);


### PR DESCRIPTION
This catches the case where `n_eligible_for_doseX` is 0, where we want to avoid division by 0. I think I've got it right here that `n_vaccination_t_X` is just 0 in that case