### PR TITLE
Reorder odin

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,8 @@
 linters: linters_with_defaults(
     indentation_linter = NULL,
     object_length_linter = NULL,
+    object_name_linter = NULL,
+    commented_code_linter = NULL,
     object_usage_linter = NULL,
     cyclocomp_linter = NULL
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mpoxseir
 Title: Stochastic compartmental model of mpox transmission
-Version: 0.1.8
+Version: 0.1.9
 Authors@R: c(person("Lilith", "Whittles", role = c("aut", "cre"),
                     email = "l.whittles@imperial.ac.uk"),
              person("Ruth", "McCabe", role = c("aut")),

--- a/inst/odin/model-targeted-vax.R
+++ b/inst/odin/model-targeted-vax.R
@@ -14,9 +14,11 @@ update(time) <- (step + 1) * dt
 ## j = 3: 1 dose
 ## j = 4: 2 doses
 
-## Emergency use of the MVA-BN has not been granted for children (u18s) in DRC and so we split vaccination into two components depending on age
+## Emergency use of the MVA-BN has not been granted for children (u18s) in DRC
+## and so we split vaccination into two components depending on age
 ## below are indicators for children vs adult groups
-## use of _raw indicates that we are in prop form for the boundary category of 15 - 19
+## use of _raw indicates that we are in prop form for the boundary category
+## of 15 - 19
 children_ind_raw[] <- user()
 dim(children_ind_raw) <- c(n_group)
 adults_ind_raw[] <- user()
@@ -32,13 +34,18 @@ dim(daily_doses_children) <- c(vaccination_campaign_length_children, n_vax)
 daily_doses_adults[, ] <- user()
 dim(daily_doses_adults) <- c(vaccination_campaign_length_adults, n_vax)
 
-## with this we need to ensure daily_doses for children and adults final time step is all 0 - done outside of the model in pre-processing
-daily_doses_children_t[ ] <- if (as.integer(time) >= (vaccination_campaign_length_children))
-  daily_doses_children[vaccination_campaign_length_children, i] else daily_doses_children[time, i]
+## with this we need to ensure daily_doses for children and adults final time
+## step is all 0 - done outside of the model in pre-processing
+daily_doses_children_t[] <-
+  if (as.integer(time) >= (vaccination_campaign_length_children))
+    daily_doses_children[vaccination_campaign_length_children, i] else
+      daily_doses_children[time, i]
 dim(daily_doses_children_t) <- n_vax
 
-daily_doses_adults_t[ ] <- if (as.integer(time) >= (vaccination_campaign_length_adults))
-  daily_doses_adults[vaccination_campaign_length_adults, i] else daily_doses_adults[time, i]
+daily_doses_adults_t[] <-
+  if (as.integer(time) >= (vaccination_campaign_length_adults))
+    daily_doses_adults[vaccination_campaign_length_adults, i] else
+      daily_doses_adults[time, i]
 dim(daily_doses_adults_t) <- n_vax
 
 ## allocate the daily doses according to prioritisation strategy
@@ -49,7 +56,8 @@ N_prioritisation_steps_adults <- user()
 ## what this corresponds to in terms of groups is encoded here
 ## this is independent of dose / applies to both doses
 prioritisation_strategy_children[, ] <- user()
-dim(prioritisation_strategy_children) <- c(n_group, N_prioritisation_steps_children)
+dim(prioritisation_strategy_children) <-
+  c(n_group, N_prioritisation_steps_children)
 
 prioritisation_strategy_adults[, ] <- user()
 dim(prioritisation_strategy_adults) <- c(n_group, N_prioritisation_steps_adults)
@@ -66,20 +74,24 @@ dim(prioritisation_strategy_adults) <- c(n_group, N_prioritisation_steps_adults)
 ## targets
 
 ## has the target been met
-## for cols 1 (smallpox vax) and 2 (unvaccinated) this doesn't matter for neither children or adults, for children col 4 (2nd dose) also doesn't matter
+## for cols 1 (smallpox vax) and 2 (unvaccinated) this doesn't matter for
+## neither children or adults, for children col 4 (2nd dose) also doesn't matter
 
 ## children
 dim(target_met_children_t) <- c(n_group, n_vax)
 
 ## 1st doses
 ## if you have a 2nd dose this implies you also have had a 1st dose so account
-## for this in the 1st dose target - this now isn't strictly relevant for children but leaving it in in case we do expand this to 2 doses in future
-target_met_children_t[,] <- 0
+## for this in the 1st dose target - this now isn't strictly relevant for
+## children but leaving it in in case we do expand this to 2 doses in future
+target_met_children_t[, ] <- 0
 target_met_children_t[, 3] <-
-  ((sum(N[i, 3:4]) * children_ind_raw[i]) > prioritisation_strategy_children[i, prioritisation_step_1st_dose_children] * sum(N[i, ]))
+  ((sum(N[i, 3:4]) * children_ind_raw[i]) >
+     prioritisation_strategy_children[
+       i, prioritisation_step_1st_dose_children] * sum(N[i, ]))
 
 
-## adults 
+## adults
 dim(target_met_adults_t) <- c(n_group, n_vax)
 
 ## 1st doses
@@ -87,12 +99,16 @@ dim(target_met_adults_t) <- c(n_group, n_vax)
 ## for this in the 1st dose target
 target_met_adults_t[, ] <- 0
 target_met_adults_t[, 3] <-
-  ((sum(N[i, 3:4]) * adults_ind_raw[i]) >  prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] * sum(N[i, ]))
+  ((sum(N[i, 3:4]) * adults_ind_raw[i]) >
+     prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] *
+     sum(N[i, ]))
 
 
 ## 2nd doses
 target_met_adults_t[, 4] <-
-  ((sum(N[i, 4]) * adults_ind_raw[i]) >  prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults] * sum(N[i, ]))  
+  ((sum(N[i, 4]) * adults_ind_raw[i]) >
+     prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults] *
+     sum(N[i, ]))
 
 
 ## prioritisation step proposal to account for the fact that this would update
@@ -100,25 +116,32 @@ target_met_adults_t[, 4] <-
 ## like it to be done properly)
 
 ## the target goal for the current prioritisation strategy
-## with ceiling basically saying if there is any target in that group to account for it
-coverage_achieved_1st_dose_children[] <- ceiling(prioritisation_strategy_children[i, prioritisation_step_1st_dose_children])
+## with ceiling basically saying if there is any target in that group to account
+## for it
+coverage_achieved_1st_dose_children[] <- ceiling(
+  prioritisation_strategy_children[i, prioritisation_step_1st_dose_children])
 dim(coverage_achieved_1st_dose_children) <- c(n_group)
 
-coverage_achieved_1st_dose_adults[] <- ceiling(prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults])
+coverage_achieved_1st_dose_adults[] <- ceiling(
+  prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults])
 dim(coverage_achieved_1st_dose_adults) <- c(n_group)
 
-coverage_achieved_2nd_dose_adults[] <- ceiling(prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults])
+coverage_achieved_2nd_dose_adults[] <- ceiling(
+  prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults])
 dim(coverage_achieved_2nd_dose_adults) <- c(n_group)
 
 ## children
 prioritisation_step_1st_dose_children_proposal <-
-  if (sum(target_met_children_t[, 3]) == sum(coverage_achieved_1st_dose_children[])) 
+  if (sum(target_met_children_t[, 3]) ==
+      sum(coverage_achieved_1st_dose_children[]))
     prioritisation_step_1st_dose_children + 1 else
     prioritisation_step_1st_dose_children
 
 update(prioritisation_step_1st_dose_children) <-
-  if (prioritisation_step_1st_dose_children_proposal > N_prioritisation_steps_children)
-    N_prioritisation_steps_children else prioritisation_step_1st_dose_children_proposal
+  if (prioritisation_step_1st_dose_children_proposal >
+      N_prioritisation_steps_children)
+    N_prioritisation_steps_children else
+      prioritisation_step_1st_dose_children_proposal
 
 
 ## adults
@@ -128,8 +151,10 @@ prioritisation_step_1st_dose_adults_proposal <-
     prioritisation_step_1st_dose_adults
 
 update(prioritisation_step_1st_dose_adults) <-
-  if (prioritisation_step_1st_dose_adults_proposal > N_prioritisation_steps_adults)
-    N_prioritisation_steps_adults else prioritisation_step_1st_dose_adults_proposal
+  if (prioritisation_step_1st_dose_adults_proposal >
+      N_prioritisation_steps_adults)
+    N_prioritisation_steps_adults else
+      prioritisation_step_1st_dose_adults_proposal
 
 prioritisation_step_2nd_dose_adults_proposal <-
   if (sum(target_met_adults_t[, 4]) == sum(coverage_achieved_2nd_dose_adults[]))
@@ -137,8 +162,10 @@ prioritisation_step_2nd_dose_adults_proposal <-
     prioritisation_step_2nd_dose_adults
 
 update(prioritisation_step_2nd_dose_adults) <-
-  if (prioritisation_step_2nd_dose_adults_proposal > N_prioritisation_steps_adults)
-    N_prioritisation_steps_adults else prioritisation_step_2nd_dose_adults_proposal
+  if (prioritisation_step_2nd_dose_adults_proposal >
+      N_prioritisation_steps_adults)
+    N_prioritisation_steps_adults else
+      prioritisation_step_2nd_dose_adults_proposal
 
 
 #prioritisation_step <- user()
@@ -153,18 +180,18 @@ initial(prioritisation_step_2nd_dose_adults) <- 1
 
 ## who can get a children's dose
 n_eligible_for_dose1_children[] <- (S[i, 2] + Ea[i, 2] + Eb[i, 2] + R[i, 2]) *
-  prioritisation_strategy_children[i, prioritisation_step_1st_dose_children] 
+  prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]
 dim(n_eligible_for_dose1_children) <- c(n_group)
 ## who can get a 1st dose
 ## now we have to look in the preceding j class (e.g. who in unvaccinated j = 1
 ## can get a 1st dose and move to j = 2) as these are the people who will be
 ## eligible
 n_eligible_for_dose1_adults[] <- (S[i, 2] + Ea[i, 2] + Eb[i, 2] + R[i, 2]) *
-  prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] 
+  prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]
 dim(n_eligible_for_dose1_adults) <- c(n_group)
 ## who can get a 2nd dose
 n_eligible_for_dose2_adults[] <- (S[i, 3] + Ea[i, 3] + Eb[i, 3] + R[i, 3]) *
-  prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults] 
+  prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]
 dim(n_eligible_for_dose2_adults) <- c(n_group)
 
 ## allocate the doses to the unvaccinated by age group, prioritisation strategy
@@ -175,30 +202,40 @@ dim(n_eligible_for_dose2_adults) <- c(n_group)
 
 ## children 1st doses
 n_vaccination_t_S_children[] <- 0
-n_vaccination_t_S_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * S[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      S[i, 2])
+n_vaccination_t_S_children[] <-
+  if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+    min(floor((daily_doses_children_t[2] * S[i, 2] *
+                 prioritisation_strategy_children[
+                   i, prioritisation_step_1st_dose_children]) /
+                sum(n_eligible_for_dose1_children[])),
+        S[i, 2])
 
 n_vaccination_t_S_adults[] <- 0
 
 ## adults 1st doses
-n_vaccination_t_S_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * S[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
-      S[i, 2])
+n_vaccination_t_S_adults[] <-
+  if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+    min(floor((daily_doses_adults_t[2] * S[i, 2] *
+                 prioritisation_strategy_adults[
+                   i, prioritisation_step_1st_dose_adults]) /
+                sum(n_eligible_for_dose1_adults[])),
+        S[i, 2])
 
 ## combine total first doses
 n_vaccination_t_S[, ] <- 0
-n_vaccination_t_S[,2] <- n_vaccination_t_S_children[i] + n_vaccination_t_S_adults[i]
+n_vaccination_t_S[, 2] <-
+  n_vaccination_t_S_children[i] + n_vaccination_t_S_adults[i]
 
-## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
-n_vaccination_t_S[4,2] <- min(n_vaccination_t_S[4, 2], S[4, 2])
+## for the boundary case do an extra check that we haven't gone over the number
+## of people in each compartment
+n_vaccination_t_S[4, 2] <- min(n_vaccination_t_S[4, 2], S[4, 2])
 
 ## allocate 2nd doses (adults only for now)
 n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * S[i, 3] *
-               prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
+               prioritisation_strategy_adults[
+                 i, prioritisation_step_2nd_dose_adults]) /
+              sum(n_eligible_for_dose2_adults[])),
       S[i, 3])
 
 
@@ -206,90 +243,120 @@ n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
 
 ## children 1st doses
 n_vaccination_t_Ea_children[] <- 0
-n_vaccination_t_Ea_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * Ea[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      Ea[i, 2])
+n_vaccination_t_Ea_children[] <-
+  if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+    min(floor((daily_doses_children_t[2] * Ea[i, 2] *
+                 prioritisation_strategy_children[
+                   i, prioritisation_step_1st_dose_children]) /
+                sum(n_eligible_for_dose1_children[])),
+        Ea[i, 2])
 
 ## adults 1st doses
-n_vaccination_t_Ea_adults[ ] <- 0
-n_vaccination_t_Ea_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * Ea[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
-      Ea[i, 2])
+n_vaccination_t_Ea_adults[] <- 0
+n_vaccination_t_Ea_adults[] <-
+  if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+    min(floor((daily_doses_adults_t[2] * Ea[i, 2] *
+                 prioritisation_strategy_adults[
+                   i, prioritisation_step_1st_dose_adults]) /
+                sum(n_eligible_for_dose1_adults[])),
+        Ea[i, 2])
 
 ## combine total first doses
 n_vaccination_t_Ea[, ] <- 0
-n_vaccination_t_Ea[,2] <- n_vaccination_t_Ea_children[i] + n_vaccination_t_Ea_adults[i]
+n_vaccination_t_Ea[, 2] <-
+  n_vaccination_t_Ea_children[i] + n_vaccination_t_Ea_adults[i]
 
-## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
-n_vaccination_t_Ea[4,2] <- min(n_vaccination_t_Ea[4, 2], Ea[4, 2])
+## for the boundary case do an extra check that we haven't gone over the number
+## of people in each compartment
+n_vaccination_t_Ea[4, 2] <- min(n_vaccination_t_Ea[4, 2], Ea[4, 2])
 
 ## adults 2nd doses
 n_vaccination_t_Ea[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * Ea[i, 3] *
-               prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
+               prioritisation_strategy_adults[
+                 i, prioritisation_step_2nd_dose_adults]) /
+              sum(n_eligible_for_dose2_adults[])),
       Ea[i, 3])
 
 
 ### allocate to Eb
 
 ## children 1st doses
-n_vaccination_t_Eb_children[ ] <- 0
-n_vaccination_t_Eb_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * Eb[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      Eb[i, 2])
+n_vaccination_t_Eb_children[] <- 0
+n_vaccination_t_Eb_children[] <-
+  if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+    min(floor((daily_doses_children_t[2] * Eb[i, 2] *
+                 prioritisation_strategy_children[
+                   i, prioritisation_step_1st_dose_children]) /
+                sum(n_eligible_for_dose1_children[])),
+        Eb[i, 2])
 
 ## adults 1st doses
-n_vaccination_t_Eb_adults[ ] <- 0
-n_vaccination_t_Eb_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * Eb[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
-      Eb[i, 2])
+n_vaccination_t_Eb_adults[] <- 0
+n_vaccination_t_Eb_adults[] <-
+  if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+    min(floor((daily_doses_adults_t[2] * Eb[i, 2] *
+                 prioritisation_strategy_adults[
+                   i, prioritisation_step_1st_dose_adults]) /
+                sum(n_eligible_for_dose1_adults[])),
+        Eb[i, 2])
 
 ## combine total first doses
 n_vaccination_t_Eb[, ] <- 0
-n_vaccination_t_Eb[,2] <- n_vaccination_t_Eb_children[i] + n_vaccination_t_Eb_adults[i]
+n_vaccination_t_Eb[, 2] <-
+  n_vaccination_t_Eb_children[i] + n_vaccination_t_Eb_adults[i]
 
-## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
-n_vaccination_t_Eb[4,2] <- min(n_vaccination_t_Eb[4, 2], Eb[4, 2])
+## for the boundary case do an extra check that we haven't gone over the number
+## of people in each compartment
+n_vaccination_t_Eb[4, 2] <- min(n_vaccination_t_Eb[4, 2], Eb[4, 2])
 
 ## adults 2nd doses
 n_vaccination_t_Eb[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * Eb[i, 3] *
-               prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
+               prioritisation_strategy_adults[
+                 i, prioritisation_step_2nd_dose_adults]) /
+              sum(n_eligible_for_dose2_adults[])),
       Eb[i, 3])
 
 
 ### allocate to R
 
 ## children 1st doses
-n_vaccination_t_R_children[ ] <- 0
-n_vaccination_t_R_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * R[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      R[i, 2])
+n_vaccination_t_R_children[] <- 0
+n_vaccination_t_R_children[] <-
+  if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+    min(floor((daily_doses_children_t[2] * R[i, 2] *
+                 prioritisation_strategy_children[
+                   i, prioritisation_step_1st_dose_children]) /
+                sum(n_eligible_for_dose1_children[])),
+        R[i, 2])
 
 ## adults 1st doses
-n_vaccination_t_R_adults[ ] <- 0
-n_vaccination_t_R_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * R[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] ) / sum(n_eligible_for_dose1_adults[])),
-      R[i, 2] )
+n_vaccination_t_R_adults[] <- 0
+n_vaccination_t_R_adults[] <-
+  if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+    min(floor((daily_doses_adults_t[2] * R[i, 2] *
+                 prioritisation_strategy_adults[
+                   i, prioritisation_step_1st_dose_adults]) /
+                sum(n_eligible_for_dose1_adults[])),
+        R[i, 2])
 
 ## combine total first doses
 n_vaccination_t_R[, ] <- 0
-n_vaccination_t_R[,2] <- n_vaccination_t_R_children[i] + n_vaccination_t_R_adults[i]
+n_vaccination_t_R[, 2] <-
+  n_vaccination_t_R_children[i] + n_vaccination_t_R_adults[i]
 
-## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
-n_vaccination_t_R[4,2] <- min(n_vaccination_t_R[4, 2], R[4, 2])
+## for the boundary case do an extra check that we haven't gone over the number
+## of people in each compartment
+n_vaccination_t_R[4, 2] <- min(n_vaccination_t_R[4, 2], R[4, 2])
 
 ## adults 2nd doses
 n_vaccination_t_R[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * R[i, 3] *
-               prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
-      R[i,3])
+               prioritisation_strategy_adults[
+                 i, prioritisation_step_2nd_dose_adults]) /
+              sum(n_eligible_for_dose2_adults[])),
+      R[i, 3])
 
 
 ## net vaccination change for relevant classes (S, Ea, Eb, R)
@@ -350,12 +417,12 @@ update(D[, ]) <- D[i, j] + delta_D[i, j]
 ## Additional outputs
 update(E[, ]) <- Ea[i, j] + Eb[i, j]
 update(I[, ]) <- Ir[i, j] + Id[i, j]
-update(N[, ]) <- S[i, j] + Ea[i, j] + Eb[i, j] + Ir[i, j] + Id[i, j] + 
+update(N[, ]) <- S[i, j] + Ea[i, j] + Eb[i, j] + Ir[i, j] + Id[i, j] +
   R[i, j] +  D[i, j]
 #update(N[, ]) <- S[i, j] + E[i, j] + I[i, j] + R[i, j] + D[i, j]
 
 # weekly cases
-# group indices 
+# group indices
 # [1: 0-4,    2: 5-9,    3: 10-14,  4: 15-19,  5: 20-24,  6: 25-29,
 #  7: 30-34,  8: 35-39,  9: 40-44, 10: 45-49, 11: 50-54, 12: 55-59,
 # 13: 60-64, 14: 65-69, 15: 70-74, 16: 75+,   17: CSW,   18: ASW,
@@ -380,7 +447,7 @@ update(cases_inc_00_04) <- cases_inc_00_04 * is_same_week + new_cases_00_04
 update(cases_inc_05_14) <- cases_inc_05_14 * is_same_week + new_cases_05_14
 update(cases_inc_15_plus) <- cases_inc_15_plus * is_same_week +
   new_cases_15_plus
-  
+
 update(cases_inc_SW) <- cases_inc_SW * is_same_week + new_cases_SW
 update(cases_inc_PBS) <- cases_inc_PBS * is_same_week + new_cases_PBS
 update(cases_inc_HCW) <- cases_inc_SW * is_same_week + new_cases_HCW
@@ -467,7 +534,7 @@ s_ij_gen_pop[, ] <- m_gen_pop[i, j] * prop_infectious[j]
 # as above but for the sexual contacts only
 s_ij_sex[, ] <- m_sex[i, j] * prop_infectious[j]
 lambda[, ] <- ((beta_h * sum(s_ij_gen_pop[i, ])) +
-                 (beta_s * sum(s_ij_sex[i, ])) + beta_z[i]) * (1 - ve_I[i,j])
+                 (beta_s * sum(s_ij_sex[i, ])) + beta_z[i]) * (1 - ve_I[i, j])
 
 ## Draws from binomial distributions for numbers changing between compartments
 # accounting for vaccination:
@@ -581,7 +648,7 @@ CFR[, ] <- user()
 
 #vaccine efficacy parameters
 ve_T[] <- user()
-ve_I[,] <- user()
+ve_I[, ] <- user()
 #ve_D[,] <- user() # this is included within the CFR
 
 #Number of age classes & number of transmissibility classes
@@ -641,7 +708,7 @@ dim(beta_z) <- c(n_group)
 dim(CFR) <- c(n_group, n_vax)
 
 dim(ve_T) <- c(n_vax)
-dim(ve_I) <- c(n_group,n_vax)
+dim(ve_I) <- c(n_group, n_vax)
 
 vaccination_campaign_length_children <- user()
 vaccination_campaign_length_adults <- user()

--- a/inst/odin/model-targeted-vax.R
+++ b/inst/odin/model-targeted-vax.R
@@ -67,25 +67,25 @@ dim(prioritisation_strategy_adults) <- c(n_group, N_prioritisation_steps_adults)
 
 ## has the target been met
 ## for cols 1 (smallpox vax) and 2 (unvaccinated) this doesn't matter for neither children or adults, for children col 4 (2nd dose) also doesn't matter
-target_met_children_t[,] <- 0
-dim(target_met_children_t) <- c(n_group, n_vax)
-
-target_met_adults_t[, ] <- 0
-dim(target_met_adults_t) <- c(n_group, n_vax)
-
 
 ## children
+dim(target_met_children_t) <- c(n_group, n_vax)
+
 ## 1st doses
 ## if you have a 2nd dose this implies you also have had a 1st dose so account
 ## for this in the 1st dose target - this now isn't strictly relevant for children but leaving it in in case we do expand this to 2 doses in future
+target_met_children_t[,] <- 0
 target_met_children_t[, 3] <-
   ((sum(N[i, 3:4]) * children_ind_raw[i]) > prioritisation_strategy_children[i, prioritisation_step_1st_dose_children] * sum(N[i, ]))
 
 
 ## adults 
+dim(target_met_adults_t) <- c(n_group, n_vax)
+
 ## 1st doses
 ## if you have a 2nd dose this implies you also have had a 1st dose so account
 ## for this in the 1st dose target
+target_met_adults_t[, ] <- 0
 target_met_adults_t[, 3] <-
   ((sum(N[i, 3:4]) * adults_ind_raw[i]) >  prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] * sum(N[i, ]))
 
@@ -170,92 +170,30 @@ dim(n_eligible_for_dose2_adults) <- c(n_group)
 ## allocate the doses to the unvaccinated by age group, prioritisation strategy
 ## and across S, E, R
 ## hacky fix for now
-n_vaccination_t_S[, ] <- 0
-n_vaccination_t_Ea[, ] <- 0
-n_vaccination_t_Eb[, ] <- 0
-n_vaccination_t_R[, ] <- 0
 
+### allocate to S
+
+## children 1st doses
 n_vaccination_t_S_children[] <- 0
-n_vaccination_t_Ea_children[] <- 0
-n_vaccination_t_Eb_children[ ] <- 0
-n_vaccination_t_R_children[ ] <- 0
-
-n_vaccination_t_S_adults[] <- 0
-n_vaccination_t_Ea_adults[ ] <- 0
-n_vaccination_t_Eb_adults[ ] <- 0
-n_vaccination_t_R_adults[ ] <- 0
-
-
-### children 1st doses 
-## allocate 1st doses
 n_vaccination_t_S_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
   min(floor((daily_doses_children_t[2] * S[i, 2] *
                prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
       S[i, 2])
 
+n_vaccination_t_S_adults[] <- 0
 
-n_vaccination_t_Ea_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * Ea[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      Ea[i, 2])
-
-
-n_vaccination_t_Eb_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * Eb[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      Eb[i, 2])
-
-
-n_vaccination_t_R_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
-  min(floor((daily_doses_children_t[2] * R[i, 2] *
-               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
-      R[i, 2])
-
-
-### adults
-
-## allocate 1st doses
+## adults 1st doses
 n_vaccination_t_S_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[2] * S[i, 2] *
                prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
       S[i, 2])
-  
 
-n_vaccination_t_Ea_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * Ea[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
-      Ea[i, 2])
-  
-
-n_vaccination_t_Eb_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * Eb[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
-      Eb[i, 2])
-  
-
-n_vaccination_t_R_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
-  min(floor((daily_doses_adults_t[2] * R[i, 2] *
-               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] ) / sum(n_eligible_for_dose1_adults[])),
-      R[i, 2] )
-
-
-### combine total first doses
-
+## combine total first doses
+n_vaccination_t_S[, ] <- 0
 n_vaccination_t_S[,2] <- n_vaccination_t_S_children[i] + n_vaccination_t_S_adults[i]
 
-n_vaccination_t_Ea[,2] <- n_vaccination_t_Ea_children[i] + n_vaccination_t_Ea_adults[i]
-
-n_vaccination_t_Eb[,2] <- n_vaccination_t_Eb_children[i] + n_vaccination_t_Eb_adults[i]
-
-n_vaccination_t_R[,2] <- n_vaccination_t_R_children[i] + n_vaccination_t_R_adults[i]
-
 ## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
-
 n_vaccination_t_S[4,2] <- min(n_vaccination_t_S[4, 2], S[4, 2])
-n_vaccination_t_Ea[4,2] <- min(n_vaccination_t_Ea[4, 2], Ea[4, 2])
-n_vaccination_t_Eb[4,2] <- min(n_vaccination_t_Eb[4, 2], Eb[4, 2])
-n_vaccination_t_R[4,2] <- min(n_vaccination_t_R[4, 2], R[4, 2])
-
 
 ## allocate 2nd doses (adults only for now)
 n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
@@ -264,18 +202,90 @@ n_vaccination_t_S[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
       S[i, 3])
 
 
+### allocate to Ea
+
+## children 1st doses
+n_vaccination_t_Ea_children[] <- 0
+n_vaccination_t_Ea_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+  min(floor((daily_doses_children_t[2] * Ea[i, 2] *
+               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
+      Ea[i, 2])
+
+## adults 1st doses
+n_vaccination_t_Ea_adults[ ] <- 0
+n_vaccination_t_Ea_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+  min(floor((daily_doses_adults_t[2] * Ea[i, 2] *
+               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
+      Ea[i, 2])
+
+## combine total first doses
+n_vaccination_t_Ea[, ] <- 0
+n_vaccination_t_Ea[,2] <- n_vaccination_t_Ea_children[i] + n_vaccination_t_Ea_adults[i]
+
+## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
+n_vaccination_t_Ea[4,2] <- min(n_vaccination_t_Ea[4, 2], Ea[4, 2])
+
+## adults 2nd doses
 n_vaccination_t_Ea[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * Ea[i, 3] *
                prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
       Ea[i, 3])
 
 
+### allocate to Eb
+
+## children 1st doses
+n_vaccination_t_Eb_children[ ] <- 0
+n_vaccination_t_Eb_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+  min(floor((daily_doses_children_t[2] * Eb[i, 2] *
+               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
+      Eb[i, 2])
+
+## adults 1st doses
+n_vaccination_t_Eb_adults[ ] <- 0
+n_vaccination_t_Eb_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+  min(floor((daily_doses_adults_t[2] * Eb[i, 2] *
+               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults]) / sum(n_eligible_for_dose1_adults[])),
+      Eb[i, 2])
+
+## combine total first doses
+n_vaccination_t_Eb[, ] <- 0
+n_vaccination_t_Eb[,2] <- n_vaccination_t_Eb_children[i] + n_vaccination_t_Eb_adults[i]
+
+## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
+n_vaccination_t_Eb[4,2] <- min(n_vaccination_t_Eb[4, 2], Eb[4, 2])
+
+## adults 2nd doses
 n_vaccination_t_Eb[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * Eb[i, 3] *
                prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),
       Eb[i, 3])
 
 
+### allocate to R
+
+## children 1st doses
+n_vaccination_t_R_children[ ] <- 0
+n_vaccination_t_R_children[] <- if (sum(n_eligible_for_dose1_children[]) == 0) 0 else
+  min(floor((daily_doses_children_t[2] * R[i, 2] *
+               prioritisation_strategy_children[i, prioritisation_step_1st_dose_children]) / sum(n_eligible_for_dose1_children[])),
+      R[i, 2])
+
+## adults 1st doses
+n_vaccination_t_R_adults[ ] <- 0
+n_vaccination_t_R_adults[] <- if (sum(n_eligible_for_dose1_adults[]) == 0) 0 else
+  min(floor((daily_doses_adults_t[2] * R[i, 2] *
+               prioritisation_strategy_adults[i, prioritisation_step_1st_dose_adults] ) / sum(n_eligible_for_dose1_adults[])),
+      R[i, 2] )
+
+## combine total first doses
+n_vaccination_t_R[, ] <- 0
+n_vaccination_t_R[,2] <- n_vaccination_t_R_children[i] + n_vaccination_t_R_adults[i]
+
+## for the boundary case do an extra check that we haven't gone over the number of people in each compartment 
+n_vaccination_t_R[4,2] <- min(n_vaccination_t_R[4, 2], R[4, 2])
+
+## adults 2nd doses
 n_vaccination_t_R[, 3] <- if (sum(n_eligible_for_dose2_adults[]) == 0) 0 else
   min(floor((daily_doses_adults_t[3] * R[i, 3] *
                prioritisation_strategy_adults[i, prioritisation_step_2nd_dose_adults]) / sum(n_eligible_for_dose2_adults[])),


### PR DESCRIPTION
Reordering some stuff in the odin code (plus a bunch of delinting). The compiled code is completely unchanged.

Main reason for the reordering is that odin2 requires multiline array equations to be contiguous, not interleaved  - so we can't do e.g.
```
x[] <- 0
y[] <- 0

x[1] <- 3
y[1] <- 3
```
instead we have to do
```
x[] <- 0
x[1] <- 3

y[] <- 0
y[1] <- 3
```

So I'm making these changes now so the git diff is easier to see when we port to odin2. I've not bothered bumping the version number as functionally the package is the same.