### PR TITLE
Increase pop of SWs in Sud Kivu

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -319,7 +319,7 @@ parameters_fixed <- function(region, initial_infections, use_ve_D = FALSE, overr
   }
 
   ## Initialising variable that other parameters depend on
-  demographic_params <- parameters_demographic()
+  demographic_params <- parameters_demographic(region = region)
   age_bins <- get_age_bins()
   idx_compartment <- get_compartment_indices()
 

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -12,7 +12,7 @@
 ##' @importFrom squire get_mixing_matrix
 ##' 
 ##' @export
-parameters_demographic <- function() {
+parameters_demographic <- function(region) {
   
   age_bins <- get_age_bins()
   group_bins <- get_group_bins()
@@ -39,7 +39,12 @@ parameters_demographic <- function() {
                                      group_bins["ASW", "end"])
   N_ASW <- N_age * w_ASW
 
-  p_SW <- 0.007 * 0.5 # 0.7% women (50%) 15-49 Laga et al - assume this holds down to age 12
+  if(region=="equateur"){
+     p_SW <- 0.007 * 0.5 # 0.7% women (50%) 15-49 Laga et al - assume this holds down to age 12
+  } else if(region=="sudkivu"){
+    p_SW <- 0.03 * 0.5 # WHO press release
+  }
+  
   N_CSW <- round(p_SW * N_CSW)
   N_ASW <- round(p_SW * N_ASW)
   

--- a/tests/testthat/helper-mpoxseir.R
+++ b/tests/testthat/helper-mpoxseir.R
@@ -54,8 +54,8 @@ reference_pars_targeted_vax <- function(region = "equateur") {
 
 
 reference_names <- function() {
-  n_group <- parameters_demographic()$n_group
-  n_vax <- parameters_demographic()$n_vax
+  n_group <- parameters_demographic(region = "equateur")$n_group
+  n_vax <- parameters_demographic(region = "equateur")$n_vax
   states <- c("S", "Ea", "Eb", "Ir", "Id", "R", "D")
   list(
     states = paste0(rep(states, each = n_group*n_vax), seq_len(n_group*n_vax))

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -5,7 +5,7 @@ test_that("assign seeds works", {
 })
 
 test_that("Mixing matrices are correct", {
-  pars <- parameters_demographic()
+  pars <- parameters_demographic(region = "equateur")
   
   expect_equal(sum(pars$N0), sum(pars$N_age))
   


### PR DESCRIPTION
Updated parameters_demographic() to account for a higher prop of sex workers in Sud Kivu as discussed in hackathon 13th Dec. This requires an argument to this function that wasn't there before, but as it is primarily called from parameters_fixed() so it *should* be fine. 

Ed, once this has been merged into main I can check mpox-drc-outputs to check if this changes anything in the workflow?